### PR TITLE
Fixed calibration score so it is now between 0 and 1

### DIFF
--- a/evaluation/calibration.py
+++ b/evaluation/calibration.py
@@ -65,10 +65,10 @@ def plot_regression_calibration_curve(y_true: np.ndarray, y_pred: np.ndarray, si
     if show:
         plt.show()
 
-def compute_calibration_score(y_true: np.ndarray, y_pred: np.ndarray, sigma_pred: np.ndarray) -> float:
-    """Given the targets and outputs of a regression model, along with its predictive uncertainty, compute the calibration score of the model.
+def compute_average_calibration_score(y_true: np.ndarray, y_pred: np.ndarray, sigma_pred: np.ndarray) -> float:
+    """Given the targets and outputs of a regression model, along with its predictive uncertainty, compute the average calibration score of the model.
 
-    The calibration score is defined as 1 minus twice the area between the calibration curve of a perfectly calibrated model (y = x)
+    The average calibration score is defined as 1 minus twice the area between the calibration curve of a perfectly calibrated model (y = x)
     and the given model (the 2x multiplier is so that the score lives between 0 and 1)
     
     Args:
@@ -95,4 +95,4 @@ if __name__ == "__main__":
     sigma_pred = np.ones_like(x)    # We have nearly perfect calibration here since our model knows its uncertainty is 1.
 
     plot_regression_calibration_curve(y_true, y_pred, sigma_pred, num_bins=9)
-    print(compute_calibration_score(y_true, y_pred, sigma_pred))    # Should be close to 1.
+    print(compute_average_calibration_score(y_true, y_pred, sigma_pred))    # Should be close to 1.

--- a/evaluation/calibration.py
+++ b/evaluation/calibration.py
@@ -68,8 +68,8 @@ def plot_regression_calibration_curve(y_true: np.ndarray, y_pred: np.ndarray, si
 def compute_calibration_score(y_true: np.ndarray, y_pred: np.ndarray, sigma_pred: np.ndarray) -> float:
     """Given the targets and outputs of a regression model, along with its predictive uncertainty, compute the calibration score of the model.
 
-    The calibration score is defined as 1 minus the absolute value of the area between the calibration curve of a perfectly calibrated model (y = x)
-    and the given model.
+    The calibration score is defined as 1 minus twice the area between the calibration curve of a perfectly calibrated model (y = x)
+    and the given model (the 2x multiplier is so that the score lives between 0 and 1)
     
     Args:
         y_true (ndarray, (n,)): The true values of the regression targets.
@@ -78,10 +78,9 @@ def compute_calibration_score(y_true: np.ndarray, y_pred: np.ndarray, sigma_pred
     """
     with warnings.catch_warnings():     # Scipy passes back an annoying integration warning that doesn't affect the output.
         warnings.simplefilter("ignore")
-        area_under_model_calibration_curve = quad(lambda p: get_pct_of_targets_in_pred_confidence_interval(y_true, y_pred, sigma_pred, p), 0, 1)[0]
+        area_between_model_and_perfect_calibration_curve = quad(lambda p: abs(get_pct_of_targets_in_pred_confidence_interval(y_true, y_pred, sigma_pred, p) - p), 0, 1)[0]
 
-    area_under_perfect_calibration_curve = 0.5
-    calibration_score = 1 - abs(area_under_model_calibration_curve - area_under_perfect_calibration_curve)
+    calibration_score = 1 - (2 * area_between_model_and_perfect_calibration_curve)
     
     return calibration_score
 


### PR DESCRIPTION
I had an absolute value in the wrong place, and then realized that multiplying the "area difference" between the perfect calibration and a model's calibration by two makes it so this score lives from 0 to 1. Also, thought I'd give it a proper name: "Average Calibration Score" (inspired by Mean Average Precision since there are similar elements with aggregating over multiple thresholds)